### PR TITLE
Update OpenStructure compounds.chemlib if OpenStructure is found

### DIFF
--- a/tools/update-dictionary-script.in
+++ b/tools/update-dictionary-script.in
@@ -46,8 +46,8 @@ fetch_dictionary () {
 fetch_dictionary "@CIFPP_CACHE_DIR@/mmcif_pdbx_v50.dic" "https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic.gz"
 fetch_dictionary "@CIFPP_CACHE_DIR@/components.cif" "ftp://ftp.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
 
-# trigger update of OpenStructure compounds.chemlib
+# notify subscribers
 
-if [ -f /usr/share/openstructure/debian/update-compound-library ] ; then
-    /usr/share/openstructure/debian/update-compound-library
+if [ -d /etc/libcifpp/cache-update.d ]; then
+	run-parts --arg "@CIFPP_CACHE_DIR@" -- /etc/libcifpp/cache-update.d
 fi

--- a/tools/update-dictionary-script.in
+++ b/tools/update-dictionary-script.in
@@ -46,19 +46,8 @@ fetch_dictionary () {
 fetch_dictionary "@CIFPP_CACHE_DIR@/mmcif_pdbx_v50.dic" "https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic.gz"
 fetch_dictionary "@CIFPP_CACHE_DIR@/components.cif" "ftp://ftp.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
 
-# update OpenStructure compounds.chemlib
+# trigger update of OpenStructure compounds.chemlib
 
-if [ -f /usr/bin/chemdict_tool ] ; then
-    tmp_dir=$(mktemp --directory)
-    chown nobody:nogroup "${tmp_dir}"
-
-    gzip -c "@CIFPP_CACHE_DIR@/components.cif" > "${tmp_dir}/components.cif.gz"
-
-    # lowering privileges in order not to run as root
-    runuser -u nobody -- /usr/bin/chemdict_tool create "${tmp_dir}/components.cif.gz" "${tmp_dir}/compounds.chemlib" pdb
-
-    mkdir --parents /var/cache/openstructure
-    mv "${tmp_dir}/compounds.chemlib" /var/cache/openstructure/compounds.chemlib
-    chown root:root /var/cache/openstructure/compounds.chemlib
-    rm -rf "${tmp_dir}"
+if [ -f /usr/share/openstructure/debian/update-compound-library ] ; then
+    /usr/share/openstructure/debian/update-compound-library
 fi

--- a/tools/update-dictionary-script.in
+++ b/tools/update-dictionary-script.in
@@ -45,3 +45,20 @@ fetch_dictionary () {
 
 fetch_dictionary "@CIFPP_CACHE_DIR@/mmcif_pdbx_v50.dic" "https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic.gz"
 fetch_dictionary "@CIFPP_CACHE_DIR@/components.cif" "ftp://ftp.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
+
+# update OpenStructure compounds.chemlib
+
+if [ -f /usr/bin/chemdict_tool ] ; then
+    tmp_dir=$(mktemp --directory)
+    chown nobody:nogroup "${tmp_dir}"
+
+    gzip -c "@CIFPP_CACHE_DIR@/components.cif" > "${tmp_dir}/components.cif.gz"
+
+    # lowering privileges in order not to run as root
+    runuser -u nobody -- /usr/bin/chemdict_tool create "${tmp_dir}/components.cif.gz" "${tmp_dir}/compounds.chemlib" pdb
+
+    mkdir --parents /var/cache/openstructure
+    mv "${tmp_dir}/compounds.chemlib" /var/cache/openstructure/compounds.chemlib
+    chown root:root /var/cache/openstructure/compounds.chemlib
+    rm -rf "${tmp_dir}"
+fi


### PR DESCRIPTION
This PR implements regeneration of OpenStructure compounds library whenever the `components.cif.gz` is downloaded (see [discussion](https://lists.debian.org/debian-med/2021/09/msg00009.html)). I could not think of another way but to do this in libcifpp code.

**Edit**: After doing some thinking I am leaning towards placing the regeneration script in OpenStructure Debian package. libcifpp would only be responsible for calling it after updating `components.cif`.

**Edit 2**: No triggers for OpenStructure in libcifpp1.postinst is needed: OpenStructure will depend on libcifpp1 and generate the compounds library in its own postinst script.