### PR TITLE
Update Cif++.cpp

### DIFF
--- a/src/Cif++.cpp
+++ b/src/Cif++.cpp
@@ -34,6 +34,7 @@
 #include <stack>
 #include <tuple>
 #include <unordered_map>
+#include <mutex>
 
 #include <filesystem>
 


### PR DESCRIPTION
add mutex library for std::unique_lock, not included in std lib
- Even with the cmake CXX flags this errors for me under various flavours of linux dockerimages.
-  Someone should double check this is a sane thing to change, I am no C++ programmer! :)