### PR TITLE
Fixed installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,9 @@ On linux e.g. you would issue the following commands:
 ```
 	git clone https://github.com/PDB-REDO/libcifpp.git
 	cd libcifpp
-	mkdir build
-	cd build
-	cmake ..
-	cmake --build . --config Release
-	ctest -C Release
-	cmake --install .
+	cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/path/to/libcifpp/ -DCMAKE_BUILD_TYPE=Release
+	cmake --build build
+	cmake --install build
 ```
 This checks out the source code from github, creates a new directory
 where cmake stores its files. Run a configure, build the code and run


### PR DESCRIPTION
Installation commands in the readme cause an error when running last command `cmake --install .` because of the lack of sudo privileges. The following commands don't require sudo to run successfully and install the library.