### PR TITLE
Compilation did not work until linked with zlib

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -1,6 +1,6 @@
 CXX = c++ -std=c++17
 CXXFLAGS = $(shell pkg-config --cflags libcifpp)
-LIBS = $(shell pkg-config --libs libcifpp)
+LIBS = $(shell pkg-config --libs libcifpp) -lz
 
 all: example
 


### PR DESCRIPTION
I was getting this error when running make:
```
/usr/bin/ld: /usr/local/lib/libcifpp.a(file.cpp.o): in function `cif::gzio::basic_ogzip_streambuf<char, std::char_traits<char>, 256ul>::overflow(int)':
file.cpp:(.text._ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE8overflowEi[_ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE8overflowEi]+0x103): undefined reference to `deflate'
/usr/bin/ld: /usr/local/lib/libcifpp.a(file.cpp.o): in function `cif::gzio::basic_ogzip_streambuf<char, std::char_traits<char>, 256ul>::init(std::basic_streambuf<char, std::char_traits<char> >*)':
file.cpp:(.text._ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E[_ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E]+0x14b): undefined reference to `deflateInit2_'
/usr/bin/ld: file.cpp:(.text._ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E[_ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E]+0x16b): undefined reference to `deflateSetHeader'
/usr/bin/ld: /usr/local/lib/libcifpp.a(file.cpp.o): in function `cif::gzio::basic_ogzip_streambuf<char, std::char_traits<char>, 256ul>::close()':
file.cpp:(.text._ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE5closeEv[_ZN3cif4gzio21basic_ogzip_streambufIcSt11char_traitsIcELm256EE5closeEv]+0x59): undefined reference to `deflateEnd'
/usr/bin/ld: /usr/local/lib/libcifpp.a(file.cpp.o): in function `cif::gzio::basic_igzip_streambuf<char, std::char_traits<char>, 256ul>::underflow()':
file.cpp:(.text._ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE9underflowEv[_ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE9underflowEv]+0x111): undefined reference to `inflate'
/usr/bin/ld: /usr/local/lib/libcifpp.a(file.cpp.o): in function `cif::gzio::basic_igzip_streambuf<char, std::char_traits<char>, 256ul>::init(std::basic_streambuf<char, std::char_traits<char> >*)':
file.cpp:(.text._ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E[_ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E]+0x129): undefined reference to `inflateInit2_'
/usr/bin/ld: file.cpp:(.text._ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E[_ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E]+0x1a2): undefined reference to `inflateGetHeader'
/usr/bin/ld: file.cpp:(.text._ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E[_ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE4initEPSt15basic_streambufIcS3_E]+0x1b7): undefined reference to `inflateEnd'
/usr/bin/ld: /usr/local/lib/libcifpp.a(file.cpp.o): in function `cif::gzio::basic_igzip_streambuf<char, std::char_traits<char>, 256ul>::close()':
file.cpp:(.text._ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE5closeEv[_ZN3cif4gzio21basic_igzip_streambufIcSt11char_traitsIcELm256EE5closeEv]+0x38): undefined reference to `inflateEnd'
collect2: error: ld returned 1 exit status
make: *** [makefile:8: example] Error 1
```

After adding the -lz flag it worked great