### PR TITLE
Includes with relative path & other minor improvements

### DIFF
--- a/include/cif++.hpp
+++ b/include/cif++.hpp
@@ -26,16 +26,16 @@
 
 #pragma once
 
-#include <cif++/utilities.hpp>
-#include <cif++/file.hpp>
-#include <cif++/parser.hpp>
-#include <cif++/format.hpp>
+#include "cif++/utilities.hpp"
+#include "cif++/file.hpp"
+#include "cif++/parser.hpp"
+#include "cif++/format.hpp"
 
-#include <cif++/compound.hpp>
-#include <cif++/point.hpp>
-#include <cif++/symmetry.hpp>
+#include "cif++/compound.hpp"
+#include "cif++/point.hpp"
+#include "cif++/symmetry.hpp"
 
-#include <cif++/model.hpp>
+#include "cif++/model.hpp"
 
-#include <cif++/pdb/io.hpp>
-#include <cif++/gzio.hpp>
+#include "cif++/pdb/io.hpp"
+#include "cif++/gzio.hpp"

--- a/include/cif++/category.hpp
+++ b/include/cif++/category.hpp
@@ -26,12 +26,12 @@
 
 #pragma once
 
-#include <cif++/forward_decl.hpp>
+#include "forward_decl.hpp"
 
-#include <cif++/condition.hpp>
-#include <cif++/iterator.hpp>
-#include <cif++/row.hpp>
-#include <cif++/validate.hpp>
+#include "condition.hpp"
+#include "iterator.hpp"
+#include "row.hpp"
+#include "validate.hpp"
 
 #include <array>
 

--- a/include/cif++/compound.hpp
+++ b/include/cif++/compound.hpp
@@ -29,9 +29,9 @@
 /// \file This file contains the definition for the class compound, encapsulating
 /// the information found for compounds in the CCD.
 
-#include <cif++.hpp>
-#include <cif++/atom_type.hpp>
-#include <cif++/point.hpp>
+#include "../cif++.hpp"
+#include "atom_type.hpp"
+#include "point.hpp"
 
 #include <map>
 #include <set>

--- a/include/cif++/condition.hpp
+++ b/include/cif++/condition.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/row.hpp>
+#include "row.hpp"
 
 #include <cassert>
 #include <functional>

--- a/include/cif++/datablock.hpp
+++ b/include/cif++/datablock.hpp
@@ -26,8 +26,8 @@
 
 #pragma once
 
-#include <cif++/category.hpp>
-#include <cif++/forward_decl.hpp>
+#include "category.hpp"
+#include "forward_decl.hpp"
 
 namespace cif
 {

--- a/include/cif++/dictionary_parser.hpp
+++ b/include/cif++/dictionary_parser.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/validate.hpp>
+#include "validate.hpp"
 
 namespace cif
 {

--- a/include/cif++/file.hpp
+++ b/include/cif++/file.hpp
@@ -28,9 +28,9 @@
 
 #include <list>
 
-#include <cif++/exports.hpp>
-#include <cif++/datablock.hpp>
-#include <cif++/parser.hpp>
+#include "exports.hpp"
+#include "datablock.hpp"
+#include "parser.hpp"
 
 namespace cif
 {

--- a/include/cif++/forward_decl.hpp
+++ b/include/cif++/forward_decl.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/exports.hpp>
+#include "exports.hpp"
 
 #include <string>
 #include <vector>

--- a/include/cif++/item.hpp
+++ b/include/cif++/item.hpp
@@ -26,10 +26,10 @@
 
 #pragma once
 
-#include <cif++/exports.hpp>
-#include <cif++/forward_decl.hpp>
-#include <cif++/text.hpp>
-#include <cif++/utilities.hpp>
+#include "exports.hpp"
+#include "forward_decl.hpp"
+#include "text.hpp"
+#include "utilities.hpp"
 
 #include <cassert>
 #include <charconv>

--- a/include/cif++/iterator.hpp
+++ b/include/cif++/iterator.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/row.hpp>
+#include "row.hpp"
 
 #include <array>
 

--- a/include/cif++/model.hpp
+++ b/include/cif++/model.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/atom_type.hpp>
+#include "atom_type.hpp"
 
 #include <numeric>
 

--- a/include/cif++/parser.hpp
+++ b/include/cif++/parser.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/row.hpp>
+#include "row.hpp"
 
 #include <map>
 #include <regex>

--- a/include/cif++/pdb/cif2pdb.hpp
+++ b/include/cif++/pdb/cif2pdb.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++.hpp>
+#include "../../cif++.hpp"
 
 namespace cif::pdb
 {

--- a/include/cif++/pdb/io.hpp
+++ b/include/cif++/pdb/io.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++.hpp>
+#include "../../cif++.hpp"
 
 namespace cif::pdb
 {

--- a/include/cif++/pdb/pdb2cif.hpp
+++ b/include/cif++/pdb/pdb2cif.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++.hpp>
+#include "../../cif++.hpp"
 
 namespace cif::pdb
 {

--- a/include/cif++/pdb/pdb2cif_remark_3.hpp
+++ b/include/cif++/pdb/pdb2cif_remark_3.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/pdb/pdb2cif.hpp>
+#include "pdb2cif.hpp"
 
 // --------------------------------------------------------------------
 

--- a/include/cif++/pdb/tls.hpp
+++ b/include/cif++/pdb/tls.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++.hpp>
+#include "../../cif++.hpp"
 
 #include <string>
 #include <tuple>

--- a/include/cif++/point.hpp
+++ b/include/cif++/point.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/exports.hpp>
+#include "exports.hpp"
 
 #include <array>
 #include <cmath>

--- a/include/cif++/row.hpp
+++ b/include/cif++/row.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/item.hpp>
+#include "item.hpp"
 
 #include <array>
 

--- a/include/cif++/symmetry.hpp
+++ b/include/cif++/symmetry.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/exports.hpp>
+#include "exports.hpp"
 
 #include <array>
 #include <cstdint>

--- a/include/cif++/text.hpp
+++ b/include/cif++/text.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/exports.hpp>
+#include "exports.hpp"
 
 #include <charconv>
 #include <cmath>

--- a/include/cif++/utilities.hpp
+++ b/include/cif++/utilities.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/exports.hpp>
+#include "exports.hpp"
 
 #include <filesystem>
 

--- a/include/cif++/validate.hpp
+++ b/include/cif++/validate.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <cif++/text.hpp>
+#include "text.hpp"
 
 #include <filesystem>
 #include <list>

--- a/src/pdb/cif2pdb.cpp
+++ b/src/pdb/cif2pdb.cpp
@@ -3359,7 +3359,7 @@ std::tuple<int, int> WriteCoordinatesForModel(std::ostream &pdbFile, const datab
 	auto &atom_site_anisotrop = db["atom_site_anisotrop"];
 	auto &entity = db["entity"];
 	auto &pdbx_poly_seq_scheme = db["pdbx_poly_seq_scheme"];
-	auto &pdbx_nonpoly_scheme = db["pdbx_nonpoly_scheme"];
+	//auto &pdbx_nonpoly_scheme = db["pdbx_nonpoly_scheme"];
 	auto &pdbx_branch_scheme = db["pdbx_branch_scheme"];
 
 	int serial = 1;


### PR DESCRIPTION
```
/home/msalinas/Documents/standalone-installations/cifParsers/libcifpp/src/pdb/cif2pdb.cpp: In function ‘std::tuple<int, int> cif::pdb::WriteCoordinatesForModel(std::ostream&, const cif::datablock&, const std::map<std::__cxx11::basic_string<char>, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, std::set<std::__cxx11::basic_string<char> >&, int)’:
/home/msalinas/Documents/standalone-installations/cifParsers/libcifpp/src/pdb/cif2pdb.cpp:3362:15: warning: unused variable ‘pdbx_nonpoly_scheme’ [-Wunused-variable]
 3362 |         auto &pdbx_nonpoly_scheme = db["pdbx_nonpoly_scheme"];
      |         
```
This warning appeared while compiling the library. The use of that variable below has been commented, so I think it's appropiate to do the same thing with the unused variable.

Edit: Now I also modified the includes inside the `includes` folder. This is done to support local usage of this library without the need of installing the library system-wide (which supports multiple instances of different versions used each one by a different piece of software). System wide installations should remain unaffected by this change. 