### PR TITLE
Removed unused argument warning

### DIFF
--- a/include/cif++/condition.hpp
+++ b/include/cif++/condition.hpp
@@ -58,7 +58,7 @@ namespace detail
 		virtual void str(std::ostream &) const = 0;
 		virtual std::optional<row_handle> single() const { return {}; };
 
-		virtual bool equals(const condition_impl *rhs) const { return false; }
+		virtual bool equals([[maybe_unused]] const condition_impl *rhs) const { return false; }
 	};
 
 	struct all_condition_impl : public condition_impl


### PR DESCRIPTION
As argument rhs is not being used in that equals (should the equals function always return false?), I added that flag so the compiler skips that warning.