### PR TITLE
Proposed fix for comparing floating points (needed on macOS)

### DIFF
--- a/include/cif++/item.hpp
+++ b/include/cif++/item.hpp
@@ -608,6 +608,8 @@ struct item_handle::item_value_as<T, std::enable_if_t<std::is_arithmetic_v<T> an
 				}
 				result = 1;
 			}
+			else if (std::abs(v - value) <= std::numeric_limits<value_type>::epsilon())
+				result = 0;
 			else if (v < value)
 				result = -1;
 			else if (v > value)

--- a/include/cif++/text.hpp
+++ b/include/cif++/text.hpp
@@ -378,7 +378,7 @@ std::from_chars_result from_chars(const char *first, const char *last, FloatType
 	} state = IntegerSign;
 	int sign = 1;
 	unsigned long long vi = 0;
-	long double f = 1;
+	int fl = 0, tz = 0;
 	int exponent_sign = 1;
 	int exponent = 0;
 	bool done = false;
@@ -427,7 +427,14 @@ std::from_chars_result from_chars(const char *first, const char *last, FloatType
 				if (ch >= '0' and ch <= '9')
 				{
 					vi = 10 * vi + (ch - '0');
-					f /= 10;
+
+					if (ch == '0')
+						tz += 1;
+					else
+					{
+						fl += tz + 1;
+						tz = 0;
+					}
 				}
 				else if (ch == 'e' or ch == 'E')
 					state = ExponentSign;
@@ -469,7 +476,10 @@ std::from_chars_result from_chars(const char *first, const char *last, FloatType
 
 	if (not (bool)result.ec)
 	{
-		long double v = f * vi * sign;
+		while (tz-- > 0)
+			vi /= 10;
+
+		long double v = std::pow(10, -fl) * vi * sign;
 		if (exponent != 0)
 			v *= std::pow(10, exponent * exponent_sign);
 

--- a/test/model-test.cpp
+++ b/test/model-test.cpp
@@ -163,10 +163,10 @@ _atom_type.symbol   C
 
 	if (not(expected.front() == structure.get_datablock()))
 	{
-		REQUIRE(false);
-		std::cout << expected.front() << '\n'
+		std::cerr << expected.front() << '\n'
 				  << '\n'
 				  << structure.get_datablock() << '\n';
+		REQUIRE(false);
 	}
 }
 

--- a/test/unit-3d-test.cpp
+++ b/test/unit-3d-test.cpp
@@ -163,23 +163,23 @@ TEST_CASE("dh_q_0")
 
 	p.rotate(q);
 
-	REQUIRE_THAT(p.m_x, Catch::Matchers::WithinRel(1, 0.01f));
-	REQUIRE_THAT(p.m_y, Catch::Matchers::WithinRel(0, 0.01f));
-	REQUIRE_THAT(p.m_z, Catch::Matchers::WithinRel(1, 0.01f));
+	REQUIRE(std::abs(p.m_x - 1.f) < 0.01f);
+	REQUIRE(std::abs(p.m_y - 0.f) < 0.01f);
+	REQUIRE(std::abs(p.m_z - 1.f) < 0.01f);
 
 	a = cif::dihedral_angle(t[0], t[1], t[2], p);
-	REQUIRE_THAT(a, Catch::Matchers::WithinRel(90, 0.01f));
+	REQUIRE(std::abs(a - 90.f) < 0.01f);
 
 	q = cif::construct_from_angle_axis(-90, axis);
 
 	p.rotate(q);
 
-	REQUIRE_THAT(p.m_x, Catch::Matchers::WithinRel(1, 0.01f));
-	REQUIRE_THAT(p.m_y, Catch::Matchers::WithinRel(1, 0.01f));
-	REQUIRE_THAT(p.m_z, Catch::Matchers::WithinRel(0, 0.01f));
+	REQUIRE(std::abs(p.m_x - 1.f) < 0.01f);
+	REQUIRE(std::abs(p.m_y - 1.f) < 0.01f);
+	REQUIRE(std::abs(p.m_z - 0.f) < 0.01f);
 
 	a = cif::dihedral_angle(t[0], t[1], t[2], p);
-	REQUIRE_THAT(a, Catch::Matchers::WithinRel(0, 0.01f));
+	REQUIRE(std::abs(a - 0.f) < 0.01f);
 
 }
 

--- a/test/unit-v2-test.cpp
+++ b/test/unit-v2-test.cpp
@@ -50,6 +50,32 @@ cif::file operator""_cf(const char *text, std::size_t length)
 
 // --------------------------------------------------------------------
 
+TEST_CASE("from_chars_1")
+{
+auto f = R"(data_TEST
+#
+loop_
+_test.v
+616.487
+616.487000
+    )"_cf;
+
+	auto &db = f.front();
+	auto &c = db.front();
+
+	auto r1 = c.front();
+	REQUIRE(r1.get<double>("v") == 616.487);
+	REQUIRE(r1["v"].compare(616.487) == 0);
+
+	auto r2 = c.back();
+	REQUIRE(r2.get<double>("v") == 616.487);
+	REQUIRE(r2["v"].compare(616.487) == 0);
+
+
+}
+
+// --------------------------------------------------------------------
+
 TEST_CASE("id_1")
 {
 	REQUIRE(cif::cif_id_for_number(0) == "A");


### PR DESCRIPTION
Since the value returned from my own implementation of std::from_chars is not round trip correct, we compare the result taking into account epsilon.